### PR TITLE
Add "Send Break (ON key press)" menu option to trigger OS Break

### DIFF
--- a/app/src/main/java/com/graph89/emulationcore/ActionsList.java
+++ b/app/src/main/java/com/graph89/emulationcore/ActionsList.java
@@ -53,17 +53,18 @@ public class ActionsList extends ListView
 	public static List<ListItem>	ActionEntries			= null;
 
 	public static final int			SHOW_KEYBOARD			= 0;
-	public static final int			INSTALL_APPS			= 1;
-	public static final int			TAKE_SCREENSHOT			= 2;
-	public static final int			SYNCHRONIZE_CLOCK		= 3;
-	public static final int			LOAD_STATE				= 4;
-	public static final int			SAVE_STATE				= 5;
-	public static final int			RESET					= 6;
-	public static final int			BACKUP_MANAGER			= 7;
-	public static final int			ROM_MANAGER				= 8;
-	public static final int 		INSTANCE_CONFIGURATION	= 9;
-	public static final int			GLOBAL_CONFIGURATION	= 10;
-	public static final int			ABOUT					= 11;
+	public static final int			SEND_ON_KEY_PRESS		= 1;
+	public static final int			INSTALL_APPS			= 2;
+	public static final int			TAKE_SCREENSHOT			= 3;
+	public static final int			SYNCHRONIZE_CLOCK		= 4;
+	public static final int			LOAD_STATE				= 5;
+	public static final int			SAVE_STATE				= 6;
+	public static final int			RESET					= 7;
+	public static final int			BACKUP_MANAGER			= 8;
+	public static final int			ROM_MANAGER				= 9;
+	public static final int 		INSTANCE_CONFIGURATION	= 10;
+	public static final int			GLOBAL_CONFIGURATION	= 11;
+	public static final int			ABOUT					= 12;
 
 	private Context					mContext				= null;
 	private ListViewAdapter			mAdapter				= null;
@@ -72,6 +73,7 @@ public class ActionsList extends ListView
 	{
 		ActionEntries = new ArrayList<ListItem>();
 		ActionEntries.add(new ListItem(SHOW_KEYBOARD, "Show Keyboard"));
+		ActionEntries.add(new ListItem(SEND_ON_KEY_PRESS, "Send Break (ON Key Press)"));
 		ActionEntries.add(new ListItem(INSTALL_APPS, "Install Application / Send Files"));
 		ActionEntries.add(new ListItem(TAKE_SCREENSHOT, "Take Screenshot"));
 		ActionEntries.add(new ListItem(SYNCHRONIZE_CLOCK, "Synchronize Clock"));
@@ -115,6 +117,10 @@ public class ActionsList extends ListView
 				{
 					case SHOW_KEYBOARD:
 						activity.ShowKeyboard();
+						activity.HideActions();
+						break;
+					case SEND_ON_KEY_PRESS:
+						activity.SendOnKeyPress();
 						activity.HideActions();
 						break;
 					case INSTALL_APPS:

--- a/app/src/main/java/com/graph89/emulationcore/EmulatorActivity.java
+++ b/app/src/main/java/com/graph89/emulationcore/EmulatorActivity.java
@@ -558,6 +558,15 @@ public class EmulatorActivity extends Graph89ActivityBase
 		}
 	}
 
+	public void SendOnKeyPress()
+	{
+		if (view != null) {
+			Log.i("Graph89", "Send Break (ON Key Press)");
+			nativeSendKey(CurrentSkin.CalculatorInfo.OnKey, 1);
+			view.postDelayed(() -> nativeSendKey(CurrentSkin.CalculatorInfo.OnKey, 0), 500);
+		}
+	}
+
 	public void ShowKeyboard()
 	{
 		if (!InitComplete) return;


### PR DESCRIPTION
### Summary

As suggested in issue [#12](https://github.com/eanema/graph89/issues/12), this pull request adds a "Send Break (ON key press)" option to the Emulation menu, implemented by simulating an ON key press.

This feature allows users to trigger a low-level OS break directly from the UI when the calculator is busy, stuck in an infinite loop, or waiting for I/O—situations that previously could not be interrupted.

While not as quick as a dedicated key, this approach is straightforward and preserves the existing behavior of the EMU key.

### Testing

- Successfully tested on all emulated calculators: **TI-83/84/89/92+/V200**
- Interrupts long calculations (e.g., try `det(randMat(40,40))`, infinite loops, or I/O mode.
- Matches behavior of the TiEmu emulator, which has direct ON key access.
- Interestingly, pressing the 2nd or diamond key before sending ON results in the calculator turning off. Sending another ON turns it back on — this is consistent with real hardware and other emulators.

### Screenshots

<img width="30%" alt="Screenshot_TI-89" src="https://github.com/user-attachments/assets/096a758c-4a50-405c-91f4-cdea6291386e" />

<img width="30%" alt="Screenshot_TI-84" src="https://github.com/user-attachments/assets/6ee43520-af05-4973-a922-c3df5205a37d" />
