### PR TITLE
Feature: Swipe-Up Gesture for 2nd Key Combinations

### DIFF
--- a/app/src/main/java/com/graph89/common/CalculatorInfoBase.java
+++ b/app/src/main/java/com/graph89/common/CalculatorInfoBase.java
@@ -25,4 +25,5 @@ public abstract class CalculatorInfoBase
 	public int ScreenWidth = 0;
 	public int ScreenHeight = 0;
 	public int OnKey = -1;
+	public int SecondKey = -1;  // -1 indicates no 2nd key support
 }

--- a/app/src/main/java/com/graph89/common/CalculatorInfoTI84.java
+++ b/app/src/main/java/com/graph89/common/CalculatorInfoTI84.java
@@ -26,5 +26,6 @@ public class CalculatorInfoTI84 extends CalculatorInfoBase
 		ScreenWidth = 96;
 		ScreenHeight = 64;
 		OnKey = 41;
+		SecondKey = 54;
 	}
 }

--- a/app/src/main/java/com/graph89/common/CalculatorInfoTI89.java
+++ b/app/src/main/java/com/graph89/common/CalculatorInfoTI89.java
@@ -26,5 +26,6 @@ public class CalculatorInfoTI89 extends CalculatorInfoBase
 		ScreenWidth = 160;
 		ScreenHeight = 100;
 		OnKey = 78;
+		SecondKey = 7;
 	}
 }

--- a/app/src/main/java/com/graph89/common/CalculatorInfoV200.java
+++ b/app/src/main/java/com/graph89/common/CalculatorInfoV200.java
@@ -26,5 +26,6 @@ public class CalculatorInfoV200 extends CalculatorInfoBase
 		ScreenWidth = 240;
 		ScreenHeight = 128;
 		OnKey = 78;
+		SecondKey = 7;
 	}
 }

--- a/app/src/main/java/com/graph89/common/ConfigurationHelper.java
+++ b/app/src/main/java/com/graph89/common/ConfigurationHelper.java
@@ -34,12 +34,14 @@ public class ConfigurationHelper
 	public static final String CONF_KEY_HAPTIC_FEEDBACK = "haptic_feedback";
 	public static final String CONF_KEY_AUDIO_FEEDBACK = "audio_feedback";
 	public static final String CONF_KEY_UNIQUE_ID = "unique_id";
+	public static final String CONF_KEY_SWIPE_GESTURE_ENABLED = "swipe_gesture_enabled";
 
 	public static final boolean CONF_DEFAULT_HIDE_STATUSBAR = false;
 	public static final boolean CONF_DEFAULT_KEEP_SCREEN_ON = false;
 	public static final int CONF_DEFAULT_AUTO_OFF = 5;
 	public static final boolean CONF_DEFAULT_HAPTIC_FEEDBACK = true;
 	public static final boolean CONF_DEFAULT_AUDIO_FEEDBACK = false;
+	public static final boolean CONF_DEFAULT_SWIPE_GESTURE_ENABLED = true;
 
 	private static SharedPreferences getSharedPrefs(Context context) {
 		return context.getSharedPreferences(ConfigurationName, Context.MODE_PRIVATE);

--- a/app/src/main/java/com/graph89/emulationcore/ButtonState.java
+++ b/app/src/main/java/com/graph89/emulationcore/ButtonState.java
@@ -22,12 +22,17 @@ package com.graph89.emulationcore;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.os.Handler;
+import android.os.Looper;
+
+import com.graph89.common.HighlightInfo;
 import com.graph89.common.KeyPress;
 
 public class ButtonState
 {
 	public static int				ActivePointerID	= -1;
 	private static List<KeyPress>	sPressedButtons	= new ArrayList<KeyPress>();
+	private static Handler			sHandler		= new Handler(Looper.getMainLooper());
 
 	public static void Reset()
 	{
@@ -73,6 +78,97 @@ public class ButtonState
 		}
 	}
 
+	/**
+	 * Highlight button visually without sending key to calculator engine.
+	 * Used during gesture detection window to provide immediate feedback
+	 * while deferring actual key dispatch decision.
+	 *
+	 * @param key The key to highlight (contains keyCode and touchID)
+	 */
+	public static void ButtonPressVisualOnly(KeyPress key)
+	{
+		if (IsKeyCodeInvalid(key.KeyCode)) return;
+
+		synchronized (sPressedButtons)
+		{
+			// Check if already pressed
+			for (KeyPress k : sPressedButtons)
+			{
+				if (k.TouchID == key.TouchID) return;
+			}
+
+			// Add to pressed list for visual highlight
+			sPressedButtons.add(key);
+
+			// Redraw to show highlight (must be inside synchronized block)
+			RefreshButtonHighlightView();
+		}
+	}
+
+	/**
+	 * Remove button visual highlight without sending release to calculator.
+	 * Used when swipe is detected to clear original button highlight before
+	 * dispatching 2nd key combination.
+	 *
+	 * @param touchID The touch identifier to remove
+	 */
+	public static void ButtonUnpressVisualOnly(int touchID)
+	{
+		synchronized (sPressedButtons)
+		{
+			for (int i = 0; i < sPressedButtons.size(); ++i)
+			{
+				if (sPressedButtons.get(i).TouchID == touchID)
+				{
+					sPressedButtons.remove(i);
+					RefreshButtonHighlightView();
+					return;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Briefly highlight 2nd key to provide visual confirmation when
+	 * swipe gesture triggers a 2nd key combination. The highlight
+	 * lasts 100ms and then auto-removes.
+	 */
+	public static void ButtonPress2ndVisualFeedback()
+	{
+		if (EmulatorActivity.CurrentSkin == null || EmulatorActivity.CurrentSkin.CalculatorInfo == null) return;
+
+		int secondKey = EmulatorActivity.CurrentSkin.CalculatorInfo.SecondKey;
+		if (secondKey == -1) return;
+
+		// Get 2nd key coordinates from highlight info
+		List<HighlightInfo> highlights = EmulatorActivity.CurrentSkin.ButtonHighlights.FindHighlightInfoByKeyCode(secondKey);
+		if (highlights == null || highlights.isEmpty()) return;
+
+		HighlightInfo info = highlights.get(0);
+
+		// Create temporary visual press with special touchID and coordinates
+		final int TEMP_TOUCH_ID = -999;
+		KeyPress tempPress = new KeyPress();
+		tempPress.KeyCode = secondKey;
+		tempPress.TouchID = TEMP_TOUCH_ID;
+		tempPress.X = info.CenterX;
+		tempPress.Y = info.CenterY;
+		ButtonPressVisualOnly(tempPress);
+
+		// Trigger full feedback (haptic + acoustic) to match direct 2nd key press
+		EmulatorActivity.TriggerFeedback();
+
+		// Auto-remove after 100ms (use shared Handler instance)
+		sHandler.postDelayed(new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				ButtonUnpressVisualOnly(TEMP_TOUCH_ID);
+			}
+		}, 100);
+	}
+
 	public static void UnpressAll()
 	{
 		for (int i = 0; i < sPressedButtons.size(); ++i)
@@ -86,7 +182,10 @@ public class ButtonState
 
 	public static KeyPress[] GetPressedKeys()
 	{
-		return (KeyPress[]) sPressedButtons.toArray(new KeyPress[sPressedButtons.size()]);
+		synchronized (sPressedButtons)
+		{
+			return (KeyPress[]) sPressedButtons.toArray(new KeyPress[sPressedButtons.size()]);
+		}
 	}
 
 	private static void RefreshButtonHighlightView()

--- a/app/src/main/java/com/graph89/emulationcore/EmulatorActivity.java
+++ b/app/src/main/java/com/graph89/emulationcore/EmulatorActivity.java
@@ -540,6 +540,19 @@ public class EmulatorActivity extends Graph89ActivityBase
 		}
 	}
 
+	public static void TriggerFeedback()
+	{
+		// Trigger haptic feedback
+		if (view != null && hapticFeedback) {
+			view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
+		}
+
+		// Trigger acoustic feedback
+		if (audioManager != null && audioFeedback) {
+			audioManager.playSoundEffect(SoundEffectConstants.CLICK, 1.0f);
+		}
+	}
+
 	public static void SendKeysToCalc(int[] keys)
 	{
 		if (IsEmulating)

--- a/app/src/main/java/com/graph89/emulationcore/GlobalConfigurationPage.java
+++ b/app/src/main/java/com/graph89/emulationcore/GlobalConfigurationPage.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceCategory;
 
 import com.eanema.graph89.R;
 import com.graph89.common.ConfigurationHelper;
@@ -18,6 +19,7 @@ public class GlobalConfigurationPage extends PreferenceActivity implements OnSha
 	private SeekBarPreference mPrefAutoOff;
 	private CheckBoxPreference mPrefHapticFeedback;
 	private CheckBoxPreference mPrefAudioFeedback;
+	private CheckBoxPreference mSwipeGestureEnabled;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -71,6 +73,28 @@ public class GlobalConfigurationPage extends PreferenceActivity implements OnSha
 		mPrefAudioFeedback = (CheckBoxPreference) findPreference(ConfigurationHelper.CONF_KEY_AUDIO_FEEDBACK);
 		mPrefAudioFeedback.setChecked(ConfigurationHelper.getBoolean(this,
 				ConfigurationHelper.CONF_KEY_AUDIO_FEEDBACK, ConfigurationHelper.CONF_DEFAULT_AUDIO_FEEDBACK));
+
+		// Initialize gesture preferences
+		mSwipeGestureEnabled = (CheckBoxPreference) findPreference(
+				ConfigurationHelper.CONF_KEY_SWIPE_GESTURE_ENABLED);
+		if (mSwipeGestureEnabled != null) {
+			mSwipeGestureEnabled.setChecked(ConfigurationHelper.getBoolean(this,
+					ConfigurationHelper.CONF_KEY_SWIPE_GESTURE_ENABLED,
+					ConfigurationHelper.CONF_DEFAULT_SWIPE_GESTURE_ENABLED));
+		}
+
+		// Hide gesture settings if calculator doesn't support 2nd key
+		if (EmulatorActivity.CurrentSkin != null &&
+			EmulatorActivity.CurrentSkin.CalculatorInfo != null) {
+			int secondKey = EmulatorActivity.CurrentSkin.CalculatorInfo.SecondKey;
+			if (secondKey == -1) {
+				PreferenceCategory gestureCategory =
+					(PreferenceCategory) findPreference("gesture_settings_category");
+				if (gestureCategory != null) {
+					getPreferenceScreen().removePreference(gestureCategory);
+				}
+			}
+		}
 	}
 
 	@Override
@@ -90,6 +114,11 @@ public class GlobalConfigurationPage extends PreferenceActivity implements OnSha
 		} else if (key.equals(mPrefAudioFeedback.getKey())) {
 			ConfigurationHelper.writeBoolean(this, ConfigurationHelper.CONF_KEY_AUDIO_FEEDBACK,
 					mPrefAudioFeedback.isChecked());
+		}
+		// Gesture configuration changes
+		else if (mSwipeGestureEnabled != null && key.equals(mSwipeGestureEnabled.getKey())) {
+			ConfigurationHelper.writeBoolean(this, ConfigurationHelper.CONF_KEY_SWIPE_GESTURE_ENABLED,
+					mSwipeGestureEnabled.isChecked());
 		}
 	}
 }

--- a/app/src/main/res/layout/settings_global.xml
+++ b/app/src/main/res/layout/settings_global.xml
@@ -44,4 +44,15 @@
         android:summary="Make a click sound on key press"
         android:title="Acoustic Feedback" />
 
+    <PreferenceCategory
+        android:key="gesture_settings_category"
+        android:title="Gesture Settings" >
+    </PreferenceCategory>
+
+    <CheckBoxPreference
+        android:key="swipe_gesture_enabled"
+        android:title="Swipe for 2nd Key"
+        android:summary="Swipe up on buttons to trigger 2nd key combinations"
+        android:defaultValue="true" />
+
 </PreferenceScreen>


### PR DESCRIPTION
# Feature: Swipe-Up Gesture for 2nd Key Combinations

Implement #23 

## Summary

This PR implements an intuitive swipe-up gesture that allows users to quickly access 2nd key functions on TI calculator emulators. Instead of manually pressing the 2nd key followed by the target key, users can simply swipe up on any button to trigger the 2nd key combination.

## Motivation

On physical TI calculators, accessing functions above keys (marked in yellow/blue) requires pressing the 2nd key first, then the target key. This two-step process can be cumbersome on touchscreens, especially for frequently used functions like trigonometric operations, statistical functions, or menu navigation.

The swipe-up gesture provides a more natural and efficient way to access these secondary functions on mobile devices.

## Features

### Core Functionality
- ✅ **Swipe-up gesture detection**: Swipe up on any calculator button to trigger `2nd + key` combination
- ✅ **Multi-touch support**: Each finger tracks independently, supporting multiple simultaneous gestures
- ✅ **Intelligent threshold**: Swipe detection based on 50% of button height (adapts to different button sizes)
- ✅ **Long-press mode**: Hold button for 300ms to enter continuous press mode (useful for scrolling)

### User Experience
- ✅ **Full multi-modal feedback**:
  - Visual: Button highlight with 2nd key visual confirmation
  - Haptic: Vibration feedback (if enabled in settings)
  - Acoustic: Click sound (if enabled in settings)
- ✅ **Seamless integration**: Works alongside existing touch behavior
- ✅ **Configurable**: Simple on/off toggle in Settings → Gesture Settings

### Smart Behavior
- ✅ **ON key preservation**: ON key retains original behavior (no gesture interference)
- ✅ **Graceful degradation**: Automatically hides gesture settings for calculators without 2nd key
- ✅ **Calculator-aware**: Dynamically uses correct 2nd key code for each calculator model:
  - TI-84: Key code 54
  - TI-89: Key code 7
  - TI-Voyage 200: Key code 7

## Technical Implementation

### Architecture
- **Touch tracking**: `TouchTracker` class maintains state for each active touch point
- **Gesture detection**: `isSwipeUpGesture()` validates vertical movement and direction
- **Deferred dispatch**: Visual feedback shown immediately, key dispatch decided on touch release
- **Thread safety**: Synchronized access to shared button state

### New APIs
- `EmulatorActivity.TriggerFeedback()`: Provides haptic + acoustic feedback without key dispatch
- `ButtonState.ButtonPressVisualOnly()`: Shows visual highlight without sending key to calculator
- `ButtonState.ButtonUnpressVisualOnly()`: Removes visual highlight without sending release
- `ButtonState.ButtonPress2ndVisualFeedback()`: Briefly highlights 2nd key with full feedback

### Files Modified
- `EmulatorView.java`: Touch event handling and gesture detection logic
- `ButtonState.java`: Visual-only button press APIs and 2nd key feedback
- `EmulatorActivity.java`: Feedback trigger API
- `CalculatorInfo*.java`: Added 2nd key codes for each calculator model
- `ConfigurationHelper.java`: Added gesture enabled configuration
- `GlobalConfigurationPage.java`: Settings initialization and gesture category visibility
- `settings_global.xml`: Added gesture settings UI

## Testing

The feature has been tested with:
- ✅ Single-touch gestures (swipe up on individual buttons)
- ✅ Multi-touch gestures (multiple simultaneous swipes)
- ✅ Long-press mode (holding buttons)
- ✅ Edge cases (ON key, touch cancellation, gesture disabled mode)
- ✅ Different calculator models (TI-84, TI-89, TI-V200)
- ✅ Settings persistence (gesture toggle state)

## Configuration

### For Users
Settings → Gesture Settings → **Swipe for 2nd Key**
- Toggle on/off as needed
- Setting is automatically hidden for calculators without 2nd key support

### For Developers
Gesture parameters are defined in `EmulatorView.java`:
```java
private static final float SWIPE_THRESHOLD_RATIO = 0.5f;   // 50% of button height
private static final long LONG_PRESS_TIMEOUT = 300;         // 300ms for long-press
```

## Compatibility

- ✅ **Android versions**: Compatible with all supported Android versions (uses standard Android APIs)
- ✅ **Calculator models**: TI-84, TI-89, TI-Voyage 200
- ✅ **Backward compatible**: Gesture can be disabled to restore original behavior
- ✅ **Multi-touch**: Supports devices with multi-touch capabilities

## Demo

### Usage Example
1. User wants to calculate `sin(45)`:
   - **Before**: Tap `2nd` → Tap `SIN` → Type `45` → Enter
   - **After**: Swipe up on `SIN` → Type `45` → Enter
2. Visual feedback: Both the button and 2nd key briefly highlight
3. Haptic/acoustic feedback: User feels/hears confirmation (if enabled)

### Gesture Recognition
- **Quick tap**: Normal key press (same as before)
- **Swipe up**: Triggers 2nd + key combination
- **Long press**: Continuous key press (e.g., for scrolling)

## Pull Request Ready

This feature is **ready for review and merge**:
- ✅ All code changes implemented and tested
- ✅ Build successful (`./gradlew assembleDebug`)
- ✅ No deprecated code or debug remnants
- ✅ Follows project code style and conventions
- ✅ Comprehensive javadoc comments
- ✅ Thread-safe implementation
- ✅ Proper resource cleanup

## Future Enhancements (Optional)

Potential improvements for future iterations:
1. Swipe direction customization (down, left, right for other modifier keys)
2. Adjustable sensitivity settings (currently hardcoded at 50%)
3. Gesture tutorial on first launch
4. Haptic pattern customization for different gesture types
